### PR TITLE
Fixes bug on about page.

### DIFF
--- a/client/src/components/App.css
+++ b/client/src/components/App.css
@@ -482,18 +482,6 @@ nav a:link {
   margin: 0 auto;
 }
 
-.back-button {
-  background-color: black;
-  font-size: 20px;
-  color: lightgray;
-}
-
-.next-button {
-  background-color: black;
-  font-size: 20px;
-  color: lightgray;
-}
-
 span {
   content: '\2190';
 }
@@ -633,4 +621,8 @@ button:disabled:hover {
 
 .journal {
   display: flex;
+}
+
+.aboutContent {
+  z-index: -5;
 }


### PR DESCRIPTION
Since we are using app.js for this, our content rendered on top of our Navbar. I just added a a container div with a negative z-index inside the main App div so the Navbar would be on top and clickable.